### PR TITLE
Fallback in case PO files are missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
-dist: trusty
 python:
-  - "3.5"
+  - "3.6"
 
 services:
   - postgresql

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+Added a bit more resiliency to missing PO-files (@alextreme)
+
 ## 0.3.0
 
 * Dropped support for Django < 1.11

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/maykinmedia/mobetta.svg?branch=master)](https://travis-ci.org/maykinmedia/mobetta)
 [![codecov](https://codecov.io/gh/maykinmedia/mobetta/branch/develop/graph/badge.svg)](https://codecov.io/gh/maykinmedia/mobetta)
 [![PyPI](https://img.shields.io/pypi/v/mobetta.svg)](https://pypi.python.org/pypi/mobetta)
-[![Lintly](https://lintly.com/gh/maykinmedia/mobetta/badge.svg)](https://lintly.com/gh/maykinmedia/mobetta/)
 
 Mobetta is a reusable app to manage translation files in Django projects.
 
@@ -17,5 +16,5 @@ takes a more modern approach to problem and adds extra features, such as:
 
 ## Documentation
 
-See the [documentation on ReadTheDocs](http://mobetta.readthedocs.io/en/latest/)
+See the [documentation on ReadTheDocs](https://mobetta.readthedocs.io/en/latest/)
 for installation and usage instructions.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,9 +18,6 @@ Mobetta
 .. image:: https://img.shields.io/pypi/v/mobetta.svg
     :target: https://pypi.python.org/pypi/mobetta
 
-.. image:: https://lintly.com/gh/maykinmedia/mobetta/badge.svg
-    :target: https://lintly.com/gh/maykinmedia/mobetta/
-
 Mobetta is a reusable app to manage translation files in Django projects.
 
 It's inspired on `django-rosetta`_, but takes a more modern approach to problem

--- a/mobetta/models.py
+++ b/mobetta/models.py
@@ -53,7 +53,16 @@ class TranslationFile(models.Model):
         - fuzzy messages
         - obsolete messages
         """
-        pofile = self.get_polib_object()
+        try:
+            pofile = self.get_polib_object()
+        except:
+            return {
+                'percent_translated': 0,
+                'total_messages': 0,
+                'translated_messages': 0,
+                'fuzzy_messages': 0,
+                'obsolete_messages': 0
+            }
 
         translated_entries = len(pofile.translated_entries())
         untranslated_entries = len(pofile.untranslated_entries())

--- a/mobetta/models.py
+++ b/mobetta/models.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import logging
 import os.path
 
 from django.conf import settings
@@ -10,6 +11,8 @@ from django.utils.encoding import python_2_unicode_compatible
 import polib
 
 from .util import app_name_from_filepath
+
+logger = logging.getLogger(__name__)
 
 # UserModel represents the model used by the project
 UserModel = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
@@ -55,7 +58,8 @@ class TranslationFile(models.Model):
         """
         try:
             pofile = self.get_polib_object()
-        except:
+        except Exception as exc:
+            logger.warning("Could not get polib object", exc_info=True)
             return {
                 'percent_translated': 0,
                 'total_messages': 0,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ os.chdir(basedir)
 
 setup(
     name='mobetta',
-    version='0.3.0',
+    version='0.3.1',
     license='BSD',
 
     # packaging


### PR DESCRIPTION
This was an issue due to the Python 3.4-> 3.5 upgrade, Mobetta keeps the 'old' references but can't deal with the fact that the .po file it points to is missing.