### PR TITLE
🔨 Changed the import from django.utils.encoding to six

### DIFF
--- a/mobetta/models.py
+++ b/mobetta/models.py
@@ -6,7 +6,7 @@ import os.path
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 import polib
 


### PR DESCRIPTION
When you import `python_2_unicode_compatible` from `django.utils.encoding` then you will raise an error called: 'ImportError: cannot import name 'python_2_unicode_compatible' from 'django.utils.encoding''